### PR TITLE
Fixing a bug with shutdown

### DIFF
--- a/systemctl.go
+++ b/systemctl.go
@@ -22,7 +22,7 @@ func (s systemctl) hibernate() {
 	runCommand(s.application, "hibernate")
 }
 
-func (s systemctl) powerOff() {
+func (s systemctl) poweroff() {
 	runCommand("poweroff")
 }
 


### PR DESCRIPTION
Fix a problem causing shutdown command to not work : 
poweroff function was named powerOff and used as poweroff the "o" should be lowercase in both cases